### PR TITLE
Add duplicate check for tasks

### DIFF
--- a/src/main/java/bob/command/AddCommand.java
+++ b/src/main/java/bob/command/AddCommand.java
@@ -28,7 +28,10 @@ public class AddCommand extends Command {
      * @param storage Storage object handling storing of tasks
      */
     public String execute(TaskManager tasks, Ui ui, Storage storage) {
-        tasks.addTask(task);
+        String addTask = tasks.addTask(task);
+        if (addTask.equals("Duplicates found")) {
+            return ui.getDuplicateString(task);
+        }
         return ui.getAddEventString(task);
     }
 }

--- a/src/main/java/bob/task/TaskManager.java
+++ b/src/main/java/bob/task/TaskManager.java
@@ -2,6 +2,7 @@ package bob.task;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -13,6 +14,7 @@ import bob.storage.Storage;
 public class TaskManager {
     private ArrayList<Task> tasks;
     private Storage storage;
+    private HashMap<String, Integer> uniqueTasks = new HashMap<>();
 
     /**
      * Constructor of TaskManager
@@ -26,6 +28,10 @@ public class TaskManager {
         } catch (IOException e) {
             this.tasks = new ArrayList<Task>();
             System.out.println("Unable to load data, starting with empty task");
+        }
+        for (int i = 0; i < tasks.size(); i++) {
+            String key = tasks.get(i).toString();
+            uniqueTasks.put(key, uniqueTasks.getOrDefault(key, 0) + 1);
         }
     }
 
@@ -42,10 +48,14 @@ public class TaskManager {
      * 
      * @param t Task to be added
      */
-    public void addTask(Task t) {
+    public String addTask(Task t) {
         assert t != null : "Task to add should not be null";
-        tasks.add(t);
-        save();
+        if (!uniqueTasks.containsKey(t.toString())) {
+            tasks.add(t);
+            save();
+            return "Task added";
+        }
+        return "Duplicates found";
     }
 
     /**

--- a/src/main/java/bob/ui/Ui.java
+++ b/src/main/java/bob/ui/Ui.java
@@ -131,4 +131,18 @@ public class Ui {
         return constructString;
     }
 
+    /**
+     * Method for printing attempt to add duplicate task
+     * 
+     * @param t duplicate task to be printed
+     * @return String to be printed on GUI
+     */
+    public String getDuplicateString(Task t) {
+        String construcString = "";
+        construcString += "Could not add task: ";
+        construcString += t.toString();
+        construcString += " due to duplicates";
+        return construcString;
+    }
+
 }


### PR DESCRIPTION
Task can be added without checking for duplicate
entries.

Let's add a duplicate check to ensure that user do not accidentally add the same task more than once.

Having duplicate task in the list could create
confusion for the user and deleting having to
delete them later is a hassle.